### PR TITLE
Augmenting transform capabilities

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -102,7 +102,7 @@ const transform = (value, schema, options) => { //TODO: Try compiling the flow u
 		value = typeHandler.transform(value, schema, options);
 
 	if(value !== undefined && schema.transform)
-		value = schema.transform(value, schema, options)
+		value = schema.transform(value, schema, options, types)
 
 	if(value !== undefined && schema.targetType)
 		value = translate(value, schema, options);


### PR DESCRIPTION
Passing `types` argument to custom `transform` function call to be able to use out-of-the-box functions in case it's necessary